### PR TITLE
Fix for Issue #10 - tgit.exe not found on windows 7 64bit

### DIFF
--- a/Tortoise.py
+++ b/Tortoise.py
@@ -553,7 +553,8 @@ class SVN():
 
 class Git():
     def __init__(self, tortoise_proc_path, root_dir):
-        self.git_path = os.path.dirname(tortoise_proc_path) + '\\tgit.exe'
+        settings = sublime.load_settings('Tortoise.sublime-settings')
+        self.git_path = settings.get('git_tgit_path') or (os.path.dirname(tortoise_proc_path) + '\\tgit.exe')
         self.root_dir = root_dir
 
     def check_status(self, path):

--- a/Tortoise.sublime-settings
+++ b/Tortoise.sublime-settings
@@ -8,6 +8,9 @@
 	// The path to the TortoiseHg thgw.exe (or hgtk.exe) executable
 	//"hg_hgtk_path": "C:\\Program Files\\TortoiseHg\\thgw.exe"
 
+	// windows users will sometimes need to set git/tgit.exe path
+	// "git_tgit_path": "C:\\Program Files\\Git\\bin\\git.exe",
+
 	// The number of seconds of time to cache VCS statuses - tweaking this may
 	// help computers with slower hard drives
 	"cache_length": 5,


### PR DESCRIPTION
I just added a configurable path to tgit/git.exe file, with fallback to the old root path relative value.
