### PR TITLE
Allow user to prefer Subversion over Git

### DIFF
--- a/Tortoise.sublime-settings
+++ b/Tortoise.sublime-settings
@@ -8,6 +8,9 @@
 	// The path to the TortoiseHg thgw.exe (or hgtk.exe) executable
 	//"hg_hgtk_path": "C:\\Program Files\\TortoiseHg\\thgw.exe"
 
+	// Sequence in which to try to load version control systems
+	"vcs_load_sequence": ["hg", "git", "svn"],
+
 	// The number of seconds of time to cache VCS statuses - tweaking this may
 	// help computers with slower hard drives
 	"cache_length": 5,


### PR DESCRIPTION
In cases where both .svn and .git directories exist (as is the case if you're [deploying to Heroku but managing code in Subversion](https://devcenter.heroku.com/articles/git#using_subversion_or_other_revision_control_systems)), the current sublime_tortoise plugin will always try to use TortoiseGit (even if it's not installed).

This patch allows a user to specify that Subversion should take precedence over Git. This seemed simpler than hiding the TortoiseGit failure conditionally (based on whether other VCS systems can work with the path in question).
